### PR TITLE
[FEAT]: Added debounced search for better performance and lower the next paint latency

### DIFF
--- a/src/app/_components/search.tsx
+++ b/src/app/_components/search.tsx
@@ -73,6 +73,9 @@ export function SearchInput({
     const [recommendations, setRecommendations] = React.useState<
         CourseAndSubjectCode[]
     >([]);
+
+    const debounceTimerRef = React.useRef<NodeJS.Timeout | null>(null);
+
     const open = recommendations.length > 0;
     const fuse = React.useMemo(() => {
         return new Fuse(Object.values(courses), {
@@ -82,9 +85,17 @@ export function SearchInput({
     }, [courses]);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const value = e.target.value;
-        setValue(value);
-        loadRecommendations(value);
+        const newValue = e.target.value;
+        setValue(newValue);
+        // Clear previous timer
+        if (debounceTimerRef.current) {
+            clearTimeout(debounceTimerRef.current);
+        }
+
+        // Set new timer
+        debounceTimerRef.current = setTimeout(() => {
+            loadRecommendations(newValue);
+        }, 200);
     };
 
     const loadRecommendations = (value: string) => {


### PR DESCRIPTION
Added debounced search to `search.tsx` so that the UI doesn't get hung while typing fast, below are the results:

Before debounced search:
![image](https://github.com/user-attachments/assets/1ee5432c-d04f-45a9-9f5b-57f576461aab)
 
After debounced search:
![image](https://github.com/user-attachments/assets/a7f7a58f-4600-4a01-8ad1-38714f427cc5)

debounce time is set to `200ms`. So it waits 200ms before loading recommendations as a user might still be typing or might be in between typing a query.