### PR TITLE
Add CONFLICT tag and search filter option

### DIFF
--- a/src/components/course-card.tsx
+++ b/src/components/course-card.tsx
@@ -2,13 +2,19 @@ import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useSchedule } from "@/store/schedule-store";
 import { terms } from "@/lib/course-utils";
+import { classSessionFitsSchedule } from "@/lib/class-session-utils";
 import { Badge } from "./ui/badge";
 import Link from "next/link";
 import { Clock, MapPin, ChevronDown } from "lucide-react";
 import { Button } from "./ui/button";
 import { Card, CardHeader, CardTitle, CardContent } from "./ui/card";
 import { cn } from "@/lib/utils";
-import { ClassSession, Course, Term } from "@/lib/types";
+import {
+    ClassSession,
+    Course,
+    ScheduleBufferMinutes,
+    Term,
+} from "@/lib/types";
 
 function KeywordHighlightedText({
     text,
@@ -42,11 +48,15 @@ export const TermClassCard = ({
     termClass,
     showCourse = false,
     isAdded,
+    isConflicting = false,
+    disableConflictingAction = false,
     onToggleTimeSlot,
 }: {
     termClass: ClassSession;
     isAdded: boolean;
     showCourse?: boolean;
+    isConflicting?: boolean;
+    disableConflictingAction?: boolean;
     onToggleTimeSlot?: (termClass: ClassSession) => void;
 }) => (
     <div
@@ -71,6 +81,11 @@ export const TermClassCard = ({
                 <Badge variant="outline" className="uppercase dark:bg-gray-700">
                     CRN: {termClass.crn}
                 </Badge>
+                {isConflicting && !isAdded && (
+                    <Badge variant="destructive" className="uppercase">
+                        CONFLICTING
+                    </Badge>
+                )}
             </div>
             <Badge variant="secondary" className="dark:bg-gray-700">
                 {terms[termClass.term]}
@@ -94,10 +109,17 @@ export const TermClassCard = ({
                     <Button
                         variant={isAdded ? "destructive" : "default"}
                         size="sm"
+                        disabled={
+                            disableConflictingAction && isConflicting && !isAdded
+                        }
                         onClick={() => onToggleTimeSlot?.(termClass)}
                         className="w-full mt-2"
                     >
-                        {isAdded ? "Remove from Schedule" : "Add to Schedule"}
+                        {isAdded
+                            ? "Remove from Schedule"
+                            : disableConflictingAction && isConflicting
+                              ? "Conflicts With Schedule"
+                              : "Add to Schedule"}
                     </Button>
                 </div>
             ) : (
@@ -117,11 +139,17 @@ export function CourseCard({
     course,
     showDescription = true,
     terms,
+    fitToScheduleOnly = false,
+    scheduleBufferMinutes = 0,
+    scheduledClasses = [],
 }: {
     keyword: string;
     terms: Term[];
     course: Course;
     showDescription?: boolean;
+    fitToScheduleOnly?: boolean;
+    scheduleBufferMinutes?: ScheduleBufferMinutes;
+    scheduledClasses?: ClassSession[];
 }) {
     const { addTimeSlot, removeTimeSlot, timeSlots } = useSchedule();
     const [visibleClasses, setVisibleClasses] = useState(
@@ -145,10 +173,24 @@ export function CourseCard({
 
     const filteredTermClasses = useMemo(
         () =>
-            course.termClasses.filter((termClass) =>
-                terms.includes(termClass.term)
-            ),
+            course.termClasses.filter((termClass) => terms.includes(termClass.term)),
         [course, terms]
+    );
+
+    const conflictingByCrn = useMemo(
+        () =>
+            new Set(
+                filteredTermClasses
+                    .filter((termClass) =>
+                        !classSessionFitsSchedule(
+                            termClass,
+                            scheduledClasses,
+                            scheduleBufferMinutes
+                        )
+                    )
+                    .map((termClass) => termClass.crn)
+            ),
+        [filteredTermClasses, scheduledClasses, scheduleBufferMinutes]
     );
 
     const addedTermClasses = useMemo(
@@ -160,12 +202,23 @@ export function CourseCard({
     );
 
     const unaddedTermClasses = useMemo(
-        () =>
-            filteredTermClasses.filter(
+        () => {
+            const classes = filteredTermClasses.filter(
                 (termClass) =>
                     !timeSlots.some((ts) => ts.class.crn === termClass.crn)
-            ),
-        [filteredTermClasses, timeSlots]
+            );
+
+            if (!fitToScheduleOnly) {
+                return classes;
+            }
+
+            return classes.sort((a, b) => {
+                const aConflicting = conflictingByCrn.has(a.crn) ? 1 : 0;
+                const bConflicting = conflictingByCrn.has(b.crn) ? 1 : 0;
+                return aConflicting - bConflicting;
+            });
+        },
+        [filteredTermClasses, timeSlots, fitToScheduleOnly, conflictingByCrn]
     );
 
     const handleShowAllClasses = () => {
@@ -235,6 +288,10 @@ export function CourseCard({
                                     key={termClass.crn}
                                     termClass={termClass}
                                     isAdded={true}
+                                    isConflicting={conflictingByCrn.has(
+                                        termClass.crn
+                                    )}
+                                    disableConflictingAction={fitToScheduleOnly}
                                 />
                             ))}
                         </div>
@@ -250,6 +307,10 @@ export function CourseCard({
                                 key={`${termClass.crn}-${termClass.section}-${termClass.term}-${course.courseCode}-${course.subjectCode}`}
                                 termClass={termClass}
                                 isAdded={false}
+                                isConflicting={conflictingByCrn.has(
+                                    termClass.crn
+                                )}
+                                disableConflictingAction={fitToScheduleOnly}
                             />
                         ))}
                 </div>

--- a/src/components/course-filter-panel.tsx
+++ b/src/components/course-filter-panel.tsx
@@ -3,8 +3,16 @@ import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import { creditHours, subjects, terms } from "@/lib/course-utils";
+import { SCHEDULE_BUFFER_MINUTES } from "@/lib/class-session-utils";
 import { RecommendationInput } from "./recommendations-input";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -77,6 +85,19 @@ export function CourseFilterPanel({
 
     const handleDeselectAllCreditHours = () => {
         onFilterUpdate({ creditHours: [] });
+    };
+
+    const handleToggleScheduleFitOnly = (
+        checked: boolean | "indeterminate"
+    ) => {
+        onFilterUpdate({ scheduleFitOnly: checked === true });
+    };
+
+    const handleScheduleBufferMinutesChange = (value: string) => {
+        onFilterUpdate({
+            scheduleBufferMinutes:
+                Number(value) as CourseFilter["scheduleBufferMinutes"],
+        });
     };
 
     return (
@@ -196,6 +217,50 @@ export function CourseFilterPanel({
                                 <Label>{creditHour}</Label>
                             </div>
                         ))}
+                    </div>
+                </div>
+
+                <Separator className="hidden md:block" />
+
+                <div className="w-full">
+                    <Label className="text-lg font-semibold mb-2 block">
+                        Schedule Fit
+                    </Label>
+                    <div className="flex items-center space-x-2 mb-3">
+                        <Checkbox
+                            id="schedule-fit-only"
+                            checked={filter.scheduleFitOnly}
+                            onCheckedChange={handleToggleScheduleFitOnly}
+                        />
+                        <Label htmlFor="schedule-fit-only">
+                            Only show classes that fit my schedule
+                        </Label>
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="schedule-buffer">
+                            Buffer Between Classes
+                        </Label>
+                        <Select
+                            value={String(filter.scheduleBufferMinutes)}
+                            onValueChange={handleScheduleBufferMinutesChange}
+                            disabled={!filter.scheduleFitOnly}
+                        >
+                            <SelectTrigger id="schedule-buffer">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {SCHEDULE_BUFFER_MINUTES.map((minutes) => (
+                                    <SelectItem
+                                        key={minutes}
+                                        value={String(minutes)}
+                                    >
+                                        {minutes === 0
+                                            ? "No buffer"
+                                            : `${minutes} minutes`}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
                     </div>
                 </div>
 

--- a/src/components/explore-courses.tsx
+++ b/src/components/explore-courses.tsx
@@ -9,14 +9,16 @@ import { CourseCard } from "./course-card";
 import { CourseFilterPanel } from "./course-filter-panel";
 import { useStoredState } from "@/hooks/use-stored-state";
 import { OrderByCourses } from "./order-courses";
+import { useSchedule } from "@/store/schedule-store";
 import type { Course, CourseFilter, CourseOrderBy } from "@/lib/types";
 
 const MAX_NUM_COURSES = 10;
 
 export function ExploreCourses({ courses }: { courses: Course[] }) {
     const [maxNumCourses, setMaxNumCourses] = useState(MAX_NUM_COURSES);
+    const { timeSlots } = useSchedule();
 
-    const [filter, setFilter] = useStoredState<CourseFilter>(
+    const [storedFilter, setFilter] = useStoredState<CourseFilter>(
         defaultFilter,
         "filter"
     );
@@ -28,7 +30,26 @@ export function ExploreCourses({ courses }: { courses: Course[] }) {
         "orderBy"
     );
 
+    const filter = useMemo(
+        () => ({ ...defaultFilter, ...storedFilter }),
+        [storedFilter]
+    );
     const debouncedFilter = useDebounce(filter, 300);
+    const scheduledClasses = useMemo(
+        () =>
+            timeSlots
+                .map((timeSlot) =>
+                    timeSlot &&
+                    typeof timeSlot === "object" &&
+                    "class" in timeSlot
+                        ? timeSlot.class
+                        : null
+                )
+                .filter((termClass): termClass is NonNullable<typeof termClass> =>
+                    Boolean(termClass)
+                ),
+        [timeSlots]
+    );
 
     const filteredCourses = useMemo(
         () =>
@@ -36,13 +57,15 @@ export function ExploreCourses({ courses }: { courses: Course[] }) {
                 courses,
                 debouncedFilter,
                 orderBy,
-                maxNumCourses
+                maxNumCourses,
+                scheduledClasses
             ),
-        [courses, debouncedFilter, maxNumCourses, orderBy]
+        [courses, debouncedFilter, maxNumCourses, orderBy, scheduledClasses]
     );
 
     const handleSearchTermChange = (searchTerm: string) => {
         setFilter((prev) => ({
+            ...defaultFilter,
             ...prev,
             searchTerm,
         }));
@@ -113,6 +136,11 @@ export function ExploreCourses({ courses }: { courses: Course[] }) {
                                 key={course.subjectCode + course.courseCode}
                                 course={course}
                                 terms={filter.terms}
+                                fitToScheduleOnly={filter.scheduleFitOnly}
+                                scheduleBufferMinutes={
+                                    filter.scheduleBufferMinutes
+                                }
+                                scheduledClasses={scheduledClasses}
                             />
                         ))}
                     </div>

--- a/src/lib/class-session-utils.ts
+++ b/src/lib/class-session-utils.ts
@@ -1,0 +1,108 @@
+import type { ClassSession, ScheduleBufferMinutes, Time } from "./types";
+
+export const SCHEDULE_BUFFER_MINUTES: ScheduleBufferMinutes[] = [
+  0, 5, 10, 15, 30,
+];
+
+function timeToMinutes(time: Exclude<Time, "C/D">): number {
+  const hour = Number.parseInt(time.slice(0, 2), 10);
+  const minute = Number.parseInt(time.slice(2, 4), 10);
+  return hour * 60 + minute;
+}
+
+function hasScheduledTime(termClass: ClassSession): boolean {
+  return termClass.time.start !== "C/D" && termClass.time.end !== "C/D";
+}
+
+function isClassSession(value: unknown): value is ClassSession {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<ClassSession>;
+
+  return (
+    typeof candidate.crn === "string" &&
+    typeof candidate.term === "string" &&
+    Array.isArray(candidate.days) &&
+    !!candidate.time &&
+    typeof candidate.time.start === "string" &&
+    typeof candidate.time.end === "string"
+  );
+}
+
+type ScheduledClassSession = ClassSession & {
+  time: {
+    start: Exclude<Time, "C/D">;
+    end: Exclude<Time, "C/D">;
+  };
+};
+
+function toScheduledClassSession(
+  termClass: ClassSession,
+): ScheduledClassSession | null {
+  if (!hasScheduledTime(termClass)) {
+    return null;
+  }
+
+  return termClass as ScheduledClassSession;
+}
+
+export function classSessionsConflict(
+  firstClass: ClassSession,
+  secondClass: ClassSession,
+  bufferMinutes = 0,
+): boolean {
+  if (!isClassSession(firstClass) || !isClassSession(secondClass)) {
+    return false;
+  }
+
+  if (firstClass.crn === secondClass.crn) {
+    return false;
+  }
+
+  if (firstClass.term !== secondClass.term) {
+    return false;
+  }
+
+  const normalizedFirstClass = toScheduledClassSession(firstClass);
+  const normalizedSecondClass = toScheduledClassSession(secondClass);
+
+  if (!normalizedFirstClass || !normalizedSecondClass) {
+    return false;
+  }
+
+  const shareDay = normalizedFirstClass.days.some((day) =>
+    normalizedSecondClass.days.includes(day),
+  );
+
+  if (!shareDay) {
+    return false;
+  }
+
+  const firstStart = timeToMinutes(normalizedFirstClass.time.start);
+  const firstEnd = timeToMinutes(normalizedFirstClass.time.end);
+  const secondStart = timeToMinutes(normalizedSecondClass.time.start);
+  const secondEnd = timeToMinutes(normalizedSecondClass.time.end);
+
+  return (
+    firstStart < secondEnd + bufferMinutes &&
+    firstEnd > secondStart - bufferMinutes
+  );
+}
+
+export function classSessionFitsSchedule(
+  candidateClass: ClassSession,
+  scheduledClasses: ClassSession[],
+  bufferMinutes = 0,
+): boolean {
+  if (!isClassSession(candidateClass)) {
+    return false;
+  }
+
+  return !scheduledClasses.some(
+    (scheduledClass) =>
+      isClassSession(scheduledClass) &&
+      classSessionsConflict(candidateClass, scheduledClass, bufferMinutes),
+  );
+}

--- a/src/lib/course-utils.ts
+++ b/src/lib/course-utils.ts
@@ -13,7 +13,9 @@ import {
     RateMyProfInstructorsByName,
     CourseAndSubjectCode,
     InstructorData,
+    ClassSession,
 } from "./types";
+import { classSessionFitsSchedule } from "./class-session-utils";
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - This is a JSON file
@@ -49,6 +51,8 @@ export const defaultFilter: CourseFilter = {
     subjectCodes: subjects.map((subject) => subject.code),
     searchTerm: "",
     creditHours,
+    scheduleFitOnly: false,
+    scheduleBufferMinutes: 0,
 };
 
 export const defaultOrderBy: CourseOrderBy = {
@@ -101,6 +105,7 @@ export function getFilteredCourses(
     filter: CourseFilter,
     orderBy: CourseOrderBy,
     maxNumCourses: number,
+    scheduledClasses: ClassSession[] = [],
 ) {
     const keywordFilteredCourses = courses.filter((course) => {
         const keyword = filter.searchTerm.toLowerCase();
@@ -112,9 +117,10 @@ export function getFilteredCourses(
     });
 
     const filteredCourses = keywordFilteredCourses.filter((course) => {
-        const hasSelectedTerm = course.termClasses.some((termClass) => {
-            return filter.terms.includes(termClass.term);
-        });
+        const classesInSelectedTerms = course.termClasses.filter((termClass) =>
+            filter.terms.includes(termClass.term),
+        );
+        const hasSelectedTerm = classesInSelectedTerms.length > 0;
         const hasSelectedCourseLevel = filter.courseLevels?.includes(
             course.courseCode[0] + "000",
         );
@@ -124,11 +130,39 @@ export function getFilteredCourses(
         const hasSelectedCreditHours = filter.creditHours?.includes(
             course.creditHours,
         );
+        const fitsExistingSchedule = !filter.scheduleFitOnly
+            ? true
+            : (() => {
+                  const lectureClasses = classesInSelectedTerms.filter(
+                      (termClass) => termClass.type === "Lec",
+                  );
+
+                  if (lectureClasses.length > 0) {
+                      // Hide the course if any lecture conflicts.
+                      return lectureClasses.every((termClass) =>
+                          classSessionFitsSchedule(
+                              termClass,
+                              scheduledClasses,
+                              filter.scheduleBufferMinutes,
+                          ),
+                      );
+                  }
+
+                  // For courses without lectures, keep prior behavior.
+                  return classesInSelectedTerms.some((termClass) =>
+                      classSessionFitsSchedule(
+                          termClass,
+                          scheduledClasses,
+                          filter.scheduleBufferMinutes,
+                      ),
+                  );
+              })();
         return (
             hasSelectedTerm &&
             hasSelectedCourseLevel &&
             hasSelectedCreditHours &&
-            hasSelectedSubjectCode
+            hasSelectedSubjectCode &&
+            fitsExistingSchedule
         );
     });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -81,7 +81,11 @@ export type CourseFilter = {
   subjectCodes: string[]; // CSCI, MATH, etc.
   searchTerm: string;
   creditHours: number[];
+  scheduleFitOnly: boolean;
+  scheduleBufferMinutes: ScheduleBufferMinutes;
 };
+
+export type ScheduleBufferMinutes = 0 | 5 | 10 | 15 | 30;
 
 export type CourseOrderByKey =
   | "title"


### PR DESCRIPTION
Tries to find courses that fit within a given schedule, adds a visual conflict tag which is always there, and option to filter on this tag. Filters only on lecture conflicts (in case of multiple lab sections). Useful for finding 3rd/4th year technical electives in some programs where can take courses across disciplines.

Quick test build at https://dalsearchprivate.vercel.app - no real testing besides trying with a few schedules I admit, but common problem. Implemented w/ codex so reject if opposed to having that usage in your project.

<img width="2050" height="1109" alt="image" src="https://github.com/user-attachments/assets/3129ae7a-2a97-4e0b-bedf-929d2be29f83" />
